### PR TITLE
Corrected URL to Nagios-Exchange page

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -28,7 +28,7 @@ pip3 install check_systemd
 
 * https://github.com/Josef-Friedrich/check_systemd
 * https://exchange.icinga.com/joseffriedrich/check_systemd
-* https://exchange.nagios.org/directory/Plugins/System-Metrics/Processes/check_systemd
+* https://exchange.nagios.org/directory/Plugins/System-Metrics/Processes/check_systemd/details
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Performance data:
 
 * https://github.com/Josef-Friedrich/check_systemd
 * https://exchange.icinga.com/joseffriedrich/check_systemd
-* https://exchange.nagios.org/directory/Plugins/System-Metrics/Processes/check_systemd
+* https://exchange.nagios.org/directory/Plugins/System-Metrics/Processes/check_systemd/details
 
 ## Testing
 


### PR DESCRIPTION
When visiting the previous URL ending with "check_systemd", I only see a page displaying the "Top-Level Directory Categories". When I append "/details", I see the check_systemd page.