### PR TITLE
Parse milliseconds in timespan strings

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -103,6 +103,7 @@ def format_timespan_to_seconds(fmt_timespan):
         'h': 60 * 60,
         'min': 60,
         's': 1,
+        'ms': 0.001,
     }
     result = 0
     for span in fmt_timespan.split():


### PR DESCRIPTION
We got the following error on some machines:

```
SYSTEMD UNKNOWN: KeyError: 'ms'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nagiosplugin/runtime.py", line 43, in wrapper
    return func(*args, **kwds)
  File "./check_systemd", line 371, in main
    check.main(args.verbose)
  File "/usr/lib/python3/dist-packages/nagiosplugin/check.py", line 120, in main
    runtime.execute(self, verbose, timeout)
  File "/usr/lib/python3/dist-packages/nagiosplugin/runtime.py", line 130, in execute
    self.run(check)
  File "/usr/lib/python3/dist-packages/nagiosplugin/runtime.py", line 117, in run
    check()
  File "/usr/lib/python3/dist-packages/nagiosplugin/check.py", line 105, in __call__
    self._evaluate_resource(resource)
  File "/usr/lib/python3/dist-packages/nagiosplugin/check.py", line 79, in _evaluate_resource
    for metric in metrics:
  File "./check_systemd", line 156, in probe
    value=format_timespan_to_seconds(match.group(1)),
  File "./check_systemd", line 112, in format_timespan_to_seconds
    result += float(value) * seconds[unit]
KeyError: 'ms'
```
The output of `systemd-analyze` is this:

```
Startup finished in 5.923s (kernel) + 17.220s (userspace) = 23.143s
graphical.target reached after 890ms in userspace
```

The code in the pull request fixes the error.