### PR TITLE
Allow for regular expression excludes

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -26,6 +26,12 @@ class SystemdctlListUnitsResource(nagiosplugin.Resource):
     def __init__(self, excludes=[]):
         self.excludes = excludes
 
+    def re_match(self,unit):
+        for exclude in self.excludes:
+            if re.match(exclude,unit):
+                return(True)
+        return(False)
+
     def probe(self):
         """Query system state and return metrics.
 
@@ -66,7 +72,7 @@ class SystemdctlListUnitsResource(nagiosplugin.Resource):
                 # failed
                 active = split_line[2]
                 # Only count not excluded units.
-                if unit not in self.excludes:
+                if not self.re_match(unit):
                     # Quick fix:
                     # Issue on Arch: “not-found” in column ACTIVE
                     # maybe cli table output changed on newer versions of
@@ -78,7 +84,7 @@ class SystemdctlListUnitsResource(nagiosplugin.Resource):
                     count_units += 1
 
             for unit in units['failed']:
-                if unit not in self.excludes:
+                if not self.re_match(unit):
                     yield Metric(name=unit, value='failed', context='unit')
 
             for active, unit_names in units.items():


### PR DESCRIPTION
I get a lot of failures like this:

`user@81463.service loaded failed failed User Manager for UID 81463`

which I would like to ignore.

Unfortunately this is not possible with the current code. Thus I added a regular expression match for exclude option.