### PR TITLE
Python3-style super() instead of faulty super(parent,)

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -176,7 +176,7 @@ class SystemctlIsActiveResource(nagiosplugin.Resource):
 
     def __init__(self, *args, **kwargs):
         self.unit = kwargs.pop('unit')
-        super(nagiosplugin.Resource, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def probe(self):
         """Query system state and return metrics.


### PR DESCRIPTION
Pylint notified me that the super() invocation referenced the parent class instead of the child. I've replaced it with a bare `super()` since this is a Python 3 script anyway.