### PR TITLE
Update the link to the Debian package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip3 install check_systemd
 
 ## Packages
 
-* Debian ([package](https://ftp-master.debian.org/new/monitoring-plugins-systemd_2.3.0+ds-1.html), [source code](https://salsa.debian.org/python-team/packages/monitoring-plugins-systemd/-/tree/debian/master/debian)): work in progress
+* Debian ([package](https://packages.debian.org/search?keywords=monitoring%2Dplugins%2Dsystemd), [source code](https://salsa.debian.org/python-team/packages/monitoring-plugins-systemd/-/tree/debian/master/debian)): in unstable
 * NixOS ([package](https://search.nixos.org/packages?channel=unstable&query=check_systemd), [source code](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/servers/monitoring/nagios/plugins/check_systemd.nix)): `nix-env -iA nixos.check_systemd`
 
 ## Command line interface


### PR DESCRIPTION
Using this link should show all the future versions packaged in Debian.
I'll try to send another patch one check_systemd is packaged in
bullseye-backports.