### PR TITLE
Add required parameter

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -466,6 +466,8 @@ class Unit:
 
         :return: A Nagios compatible exit code: 0, 1, 2, 3
         :rtype: int"""
+        if opts.required and opts.required.lower() != self.active_state:
+            return nagiosplugin.Critical
         if self.load_state == 'error' or self.active_state == 'failed':
             return nagiosplugin.Critical
         return nagiosplugin.Ok
@@ -1084,6 +1086,14 @@ def get_argparser():
         metavar='UNIT_TYPE',
         action='append',
         help='One or more unit types (for example: \'service\', \'timer\')',
+    )
+    
+    units.add_argument(
+        '--required',
+        type=str,
+        metavar='REQUIRED_STATE',
+        dest='required',
+        help='Set the state that the systemd unit must have (for example: active, inactive)',
     )
 
     # Scope: timers ###########################################################


### PR DESCRIPTION
If you set --required active - all inactive systemd units will be displayed (Result is CRITICAL).
We need to combine it with -I "xxx.service|yyy.service", because right now when yyy.service is on state inactive - the result will still be OK, but we need to be CRITICAL once one of the included systemd units are not "active" anymore