### PR TITLE
Added ability to query user units

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -673,9 +673,12 @@ class UnitCache:
 
 class CliUnitCache(UnitCache):
 
-    def __init__(self):
+    def __init__(self, with_user_units: bool = False):
         super().__init__()
-        stdout = execute_cli(['systemctl', 'list-units', '--all'])
+        command = ['systemctl', 'list-units', '--all']
+        if with_user_units:
+            command += ['--user']
+        stdout = execute_cli(command)
         if stdout:
             table_parser = TableParser(stdout)
             table_parser.check_header(('unit', 'active', 'sub', 'load'))
@@ -1211,6 +1214,11 @@ def get_argparser():
              '(cli) binaries to gather the required data for the monitoring '
              'process.'
     )
+    acquisition.add_argument(
+        '--user',
+        dest='with_user_units', action='store_true', default=False,
+        help='Also show user (systemctl --user) units.'
+    )
 
     # Performance data ########################################################
 
@@ -1278,7 +1286,7 @@ def main():
     if opts.data_source == 'dbus':
         unit_cache = DbusUnitCache()
     else:
-        unit_cache = CliUnitCache()
+        unit_cache = CliUnitCache(with_user_units=opts.with_user_units)
 
     tasks = [
         UnitsResource(),


### PR DESCRIPTION
I want to query user units. I am not sure if I should make pull request to the master branch or to the latest tag. I have added the '--user' option mainly for the cli mode, but, for some reason, it also works with dbus on my Ubuntu 20.04 virtual machine (If I change option name, then it stops working).