### PR TITLE
Exit "Unknown" when importing nagiosplugin fails

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -61,17 +61,21 @@ import re
 import subprocess
 import typing
 
-import nagiosplugin
-from nagiosplugin.check import Check
-from nagiosplugin.context import Context, ScalarContext
-from nagiosplugin.error import CheckError
-from nagiosplugin.metric import Metric
-from nagiosplugin.performance import Performance
-from nagiosplugin.range import Range
-from nagiosplugin.resource import Resource
-from nagiosplugin.result import Result, Results
-from nagiosplugin.state import Critical, Ok, ServiceState, Warn
-from nagiosplugin.summary import Summary
+try:
+    import nagiosplugin
+    from nagiosplugin.check import Check
+    from nagiosplugin.context import Context, ScalarContext
+    from nagiosplugin.error import CheckError
+    from nagiosplugin.metric import Metric
+    from nagiosplugin.performance import Performance
+    from nagiosplugin.range import Range
+    from nagiosplugin.resource import Resource
+    from nagiosplugin.result import Result, Results
+    from nagiosplugin.state import Critical, Ok, ServiceState, Warn
+    from nagiosplugin.summary import Summary
+except ImportError:
+    print("Failed to import the NagiosPlugin library.")
+    exit(3)
 
 __version__: str = "2.3.1"
 


### PR DESCRIPTION
When importing the python nagiosplugin library fails, check_systemd.py exits with exit code 1, thats Warning in Nagios/Icinga. I see 2 problems there

    * It implies the script is running (https://nagios-plugins.org/doc/guidelines.html#AEN78)
    * Warnings are mostly ignored (sad but true ... )

I suggest the script should exit with exit code 3 because the script cannot run and cannot check any thresholds.

Fixes issue #24