### PR TITLE
Always return perfdata for startup_time even with -n

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -77,7 +77,7 @@ except ImportError:
     print("Failed to import the NagiosPlugin library.")
     exit(3)
 
-__version__: str = "2.3.1"
+__version__: str = "2.3.2"
 
 
 is_gi = True

--- a/check_systemd.py
+++ b/check_systemd.py
@@ -1442,12 +1442,12 @@ def main():
     tasks: typing.List[object] = [
         UnitsResource(),
         UnitsContext(),
+        StartupTimeResource(),
         SystemdSummary(),
     ]
 
     if opts.scope_startup_time:
         tasks += [
-            StartupTimeResource(),
             StartupTimeContext(),
         ]
 


### PR DESCRIPTION
fix https://github.com/Josef-Friedrich/check_systemd/issues/26