### PR TITLE
Fix https://github.com/Josef-Friedrich/check_systemd/pull/27

### DIFF
--- a/check_systemd.py
+++ b/check_systemd.py
@@ -1442,14 +1442,10 @@ def main():
     tasks: typing.List[object] = [
         UnitsResource(),
         UnitsContext(),
-        StartupTimeResource(),
         SystemdSummary(),
+        StartupTimeResource(),
+        StartupTimeContext(),
     ]
-
-    if opts.scope_startup_time:
-        tasks += [
-            StartupTimeContext(),
-        ]
 
     if opts.scope_timers:
         tasks += [


### PR DESCRIPTION
testing for PR https://github.com/Josef-Friedrich/check_systemd/pull/27 was not complete.

now it's working:
```
# /srv/icinga/linux/check_systemd -w 10 -c 20 -n
SYSTEMD OK - all | count_units=243 data_source=cli startup_time=23.231 units_activating=0 units_active=151 units_failed=0 units_inactive=92 
# /srv/icinga/linux/check_systemd -w 10 -c 20
SYSTEMD CRITICAL - startup_time is 23.23 (outside range 0:20) | count_units=243 data_source=cli startup_time=23.231;10;20 units_activating=0 units_active=151 units_failed=0 units_inactive=92
# /srv/icinga/linux/check_systemd -w 10 -c 20 -p
SYSTEMD CRITICAL - startup_time is 23.23 (outside range 0:20)
# /srv/icinga/linux/check_systemd -w 10 -c 20 -P
SYSTEMD CRITICAL - startup_time is 23.23 (outside range 0:20) | count_units=243 data_source=cli startup_time=23.231;10;20 units_activating=0 units_active=151 units_failed=0 units_inactive=92
# /srv/icinga/linux/check_systemd -w 10 -c 20 -p -n
SYSTEMD OK - all
# /srv/icinga/linux/check_systemd -w 10 -c 20 -P -n
SYSTEMD OK - all | count_units=243 data_source=cli startup_time=23.231 units_activating=0 units_active=151 units_failed=0 units_inactive=92
```