### PR TITLE
contrib/icinga2: update for version 4.1.0

### DIFF
--- a/contrib/icinga2/command.conf
+++ b/contrib/icinga2/command.conf
@@ -1,9 +1,48 @@
 object CheckCommand "systemd_jf" {
   command = [ PluginDir + "/check_systemd" ]
+
   arguments = {
+    /* General options */
+    "-v" = {
+      set_if = "$systemd_verbose1$"
+      description = "Increase verbosity"
+    }
+    "-vv" = {
+      set_if = "$systemd_verbose2$"
+      description = "Increase verbosity more"
+    }
+    "-vvv" = {
+      set_if = "$systemd_verbose3$"
+      description = "Increase verbosity even more"
+    }
+
+    /* Options related to unit selection */
+    "--ignore-inactive-state" = {
+      value = "$systemd_ignore_inactive_state$"
+      description = {{{Ignore an inactive state on a specific unit. Oneshot
+services for example are only active while running and
+not enabled. The rest of the time they are inactive.
+This option has only an affect if it is used with the
+option -u.}}}
+    }
+    "--include" = {
+      value = "$systemd_include$"
+      description = {{{Include systemd units to the checks. This option can be
+applied multiple times, for example: -I mnt-data.mount
+-I task.service. Regular expressions can be used to
+include multiple units at once, for example: -i
+'user@\d+\.service'. For more informations see the
+Python documentation about regular expressions
+(https://docs.python.org/3/library/re.html).}}}
+      repeat_key = true
+    }
     "--unit" = {
       value = "$systemd_unit$"
       description = "Name of the systemd unit that is being tested."
+    }
+    "--include-type" = {
+      value = "$systemd_include_type$"
+      description = "One or more unit types (for example: 'service', 'timer')"
     }
     "--exclude" = {
       value = "$systemd_exclude$"
@@ -16,66 +55,80 @@ Python documentation about regular expressions
 (https://docs.python.org/3/library/re.html).}}}
       repeat_key = true
     }
+    "--exclude-unit" = {
+      value = "$systemd_exclude_unit$"
+      description = "Name of the systemd unit that is being tested."
+    }
+    "--exclude-type" = {
+      value = "$systemd_exclude_type$"
+      description = "One or more unit types (for example: 'service', 'timer')"
+    }
+    "--state" = {
+      value = "$systemd_state$"
+      description = {{{Specify the active state that the systemd unit must have
+(for example: active, inactive)}}}
+    }
+
+    /* Timers related options */
+    "--dead-timers" = {
+      value = "$systemd_dead_timers$"
+      description = {{{Detect dead / inactive timers. See the corresponding
+options '-W, --dead-timer-warning' and '-C, --dead-
+timers-critical'. Dead timers are detected by parsing
+the output of 'systemctl list-timers'. Dead timer rows
+displaying 'n/a' in the NEXT and LEFT columns and the
+time span in the column PASSED exceeds the values
+specified with the options '-W, --dead-timer-warning'
+and '-C, --dead-timers-critical'.}}}
+    }
+    "--timers-warning" = {
+      value = "$systemd_dead_timer_warning$"
+      description = {{{Time ago in seconds for dead / inactive timers to
+trigger a warning state (by default 6 days).}}}
+    }
+    "--timers-critical" = {
+      value = "$systemd_dead_timer_critical$"
+      description = {{{Time ago in seconds for dead / inactive timers to
+trigger a critical state (by default 7 days).}}}
+    }
+
+    /* Startup time related options */
     "--no-startup-time" = {
       value = "$systemd_no_startup_time$"
       description = {{{Don’t check the startup time. Using this option the
 options '-w, --warning' and '-c, --critical' have no
 effect. Performance data about the startup time is
 collected, but no critical, warning etc. states are
-triggered.
-}}}
+triggered.}}}
     }
-    "--unit" = {
-      value = "$systemd_unit$"
-      description = "Name of the systemd unit that is being tested."
-    }
-    "-w" = {
+    "--warning" = {
       value = "$systemd_warning$"
-      description = "Startup time in seconds to result in a warning status. The default is 60 seconds"
+      description = {{{Startup time in seconds to result in a warning status.
+The default is 60 seconds.}}}
     }
-    "-c" = {
+    "--critical" = {
       value = "$systemd_critical$"
-      description = "Startup time in seconds to result in a warning status. The default is 120 seconds"
+      description = {{{Startup time in seconds to result in a critical status.
+The default is 120 seconds.}}}
     }
-    "-t" = {
-      value = "$systemd_dead_timers$"
-      description = {{{Detect dead / inactive timers. See the corresponding
-options '-W, --dead-timer-warning' and '-C, --dead-
-timers-critical'. Dead timers are detected by parsing
-the output of 'systemctl list-timers'. Dead timer rows
-displaying 'n/a' in the NEXT and LEFTcolumns and the
-time span in the column PASSED exceeds the values
-specified with the options '-W, --dead-timer-warning'
-and '-C, --dead-timers-critical'.
-}}}
+
+    /* Monitoring data acquisition */
+    "--dbus" = {
+      value = "$systemd_dbus$"
+      description = {{{Use the systemd’s D-Bus API instead of parsing the text
+output of various systemd related command line
+interfaces to monitor systemd. At the moment the D-Bus
+backend of this plugin is only partially implemented.}}}
     }
-    "-W" = {
-      value = "$systemd_dead_timer_warning$"
-      description = "Time ago in seconds for dead / inactive timers to trigger a warning state (by default 6 days)"
+    "--cli" = {
+      value = "$systemd_cli$"
+      description = {{{Use the text output of serveral systemd command line
+interface (cli) binaries to gather the required data for
+the monitoring process.}}}
     }
-    "-C" = {
-      value = "$systemd_dead_timer_critical$"
-      description = "Time ago in seconds for dead / inactive timers to trigger a critical state (by default 7 days)"
-    }
-    "-i" = {
-      value = "$systemd_ignore_inactive_state$"
-      description = {{{Ignore an inactive state on a specific unit. Oneshot
-services for example are only active while running and
-not enabled. The rest of the time they are inactive.
-This option has only an affect if it is used with the
-option -u.}}}
-    }
-    "-v" = {
-      set_if = "$systemd_verbose1$"
-      description = "Increase verbosity"
-    }
-    "-vv" = {
-      set_if = "$systemd_verbose2$"
-      description = "Increase verbosity more"
-    }
-    "-vvv" = {
-      set_if = "$systemd_verbose3$"
-      description = "Increase verbosity even more"
+    "--user" = {
+      value = "$systemd_user$"
+      description = "Also show user (systemctl --user) units."
     }
   }
 }


### PR DESCRIPTION
There have been quite a few changes in the last two years. So I've updated the Icinga 2 CheckCommand to match the current help output.

First, I arranged each argument in the same order as in the help page to make future updates easier, and used the long command line argument names. I have not changed any Icinga variable names, but have introduced new variables for previously unknown flags.