### PR TITLE
contrib/icinga2: harmonize Icinga 2 config w/ ITL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <small>[Compare with latest](https://github.com/Josef-Friedrich/check_systemd/compare/v4.1.0...HEAD)</small>
 
+### Changed
+
+- Updated `contrib/icinga2/command.conf` to support latest commands and harmonize with Icinga 2 ITL upstream.
+  The two variables `systemd_dead_timer_warning` and `systemd_dead_timer_critical` were renamed to `systemd_dead_timers_warning` and `systemd_dead_timers_critical`, respectively.
+
 ## [v4.1.0] - 2024-03-01
 
 <small>[Compare with v0.4.0](https://github.com/Josef-Friedrich/check_systemd/compare/v4.0.0...v4.1.0)</small>

--- a/contrib/icinga2/command.conf
+++ b/contrib/icinga2/command.conf
@@ -4,16 +4,14 @@ object CheckCommand "systemd_jf" {
   arguments = {
     /* General options */
     "-v" = {
-      set_if = "$systemd_verbose1$"
-      description = "Increase verbosity"
+      set_if = {{ macro("$systemd_verbose_level$") == 1 }}
+      description = "Increase verbosity level (Accepted values: `1`, `2` or `3`). Defaults to none."
     }
     "-vv" = {
-      set_if = "$systemd_verbose2$"
-      description = "Increase verbosity more"
+      set_if = {{ macro("$systemd_verbose_level$") == 2 }}
     }
     "-vvv" = {
-      set_if = "$systemd_verbose3$"
-      description = "Increase verbosity even more"
+      set_if = {{ macro("$systemd_verbose_level$") == 3 }}
     }
 
     /* Options related to unit selection */
@@ -82,12 +80,12 @@ specified with the options '-W, --dead-timer-warning'
 and '-C, --dead-timers-critical'.}}}
     }
     "--timers-warning" = {
-      value = "$systemd_dead_timer_warning$"
+      value = "$systemd_dead_timers_warning$"
       description = {{{Time ago in seconds for dead / inactive timers to
 trigger a warning state (by default 6 days).}}}
     }
     "--timers-critical" = {
-      value = "$systemd_dead_timer_critical$"
+      value = "$systemd_dead_timers_critical$"
       description = {{{Time ago in seconds for dead / inactive timers to
 trigger a critical state (by default 7 days).}}}
     }


### PR DESCRIPTION
While fixing the outdated command name in the Icinga 2 ITL[^0], it was suggested to support the newer command line options there as well.

To synchronize or harmonize the ITL definition and the CheckCommand shipped here, I made small changes to not break the ITL, as I would guess that more people are using the ITL definition instead of the shipped command.conf from here.

The breaking changes were added to the CHANGELOG.

[^0]: https://github.com/Icinga/icinga2/pull/10035