### PR TITLE
Add Oracle Linux 9 / RHEL 9 Package for check_systemd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,16 @@ Packages
    `source code <https://src.fedoraproject.org/rpms/nagios-plugins-systemd>`__):
    ``dnf install nagios-plugins-systemd``
 
+-  OracleLinux9 / RHEL9
+   (`package <https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd-1.0-1.x86_64.rpm?job=release_rpm>`__,
+   `source code <https://gitlab.com/msfgitlab/check_systemd_build_rpm>`__,
+   `binary <https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd?job=release_rpm>`__):
+   This package includes one single binary compiled with the Python compiler Nuitka, including all dependencies. 
+   The package is built via GitLab CI as a nightly release and is considered experimental. 
+   ``curl -L -o check_systemd-1.0-1.x86_64.rpm "https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd-1.0-1.x86_64.rpm?job=release_rpm" && sudo dnf install -y ./check_systemd-1.0-1.x86_64.rpm``
+
+
+
 Command line interface
 ----------------------
 

--- a/README_template.rst
+++ b/README_template.rst
@@ -52,6 +52,14 @@ Packages
    (`package <https://packages.fedoraproject.org/pkgs/nagios-plugins-systemd/nagios-plugins-systemd/>`__,
    `source code <https://src.fedoraproject.org/rpms/nagios-plugins-systemd>`__):
    ``dnf install nagios-plugins-systemd``
+-  OracleLinux9 / RHEL9
+   (`package <https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd-1.0-1.x86_64.rpm?job=release_rpm>`__,
+   `source code <https://gitlab.com/msfgitlab/check_systemd_build_rpm>`__,
+   `binary <https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd?job=release_rpm>`__):
+   This package includes one single binary compiled with the Python compiler Nuitka, including all dependencies. 
+   The package is built via GitLab CI as a nightly release and is considered experimental. 
+   ``curl -L -o check_systemd-1.0-1.x86_64.rpm "https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd-1.0-1.x86_64.rpm?job=release_rpm" && sudo dnf install -y ./check_systemd-1.0-1.x86_64.rpm``
+
 
 Command line interface
 ----------------------


### PR DESCRIPTION

Hey Josef Friedrich, 

I have added the `check_systemd` package for Oracle Linux 9 / RHEL 9 to the `README_template.rst` as requested. This package includes a binary created using Nuitka, a Python compiler that transforms the `check_systemd` script along with its dependencies into a standalone executable. 

I understand Nuitka might be unfamiliar, but it helps enhance performance and distribution by compiling Python code into machine code. The package is built via GitLab CI and provided as a nightly release. Although it is currently experimental, I am actively maintaining it and ready to address any issues that may arise.

Here are the relevant details added to the list:

- **Oracle Linux 9 / RHEL 9**:
  - Source Code: [GitLab](https://gitlab.com/msfgitlab/check_systemd_build_rpm)
  - Binary (Nightly): [Download](https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd?job=release_rpm)
  - RPM (Nightly): [Download RPM](https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd-1.0-1.x86_64.rpm?job=release_rpm)
  
Installation:

```bash
curl -L -o check_systemd-1.0-1.x86_64.rpm "https://gitlab.com/msfgitlab/check_systemd_build_rpm/-/jobs/artifacts/main/raw/output/check_systemd-1.0-1.x86_64.rpm?job=release_rpm" && sudo dnf install -y ./check_systemd-1.0-1.x86_64.rpm
```

Thank you for considering this addition, and please let me know if there are any adjustments needed!

Best regards,  

Martin

